### PR TITLE
Bug fix for float object is not subscriptable

### DIFF
--- a/adafruit_matrixportal/matrixportal.py
+++ b/adafruit_matrixportal/matrixportal.py
@@ -84,6 +84,7 @@ class MatrixPortal:
             status_neopixel=status_neopixel,
             esp=esp,
             external_spi=external_spi,
+            extract_values=False,
             debug=debug,
         )
 


### PR DESCRIPTION
I seemed to have missed adding this parameter with my last PR. This fixes an error:
```
Traceback (most recent call last):
  File "code.py", line 48, in <module>
  File "code.py", line 45, in <module>
  File "adafruit_matrixportal/matrixportal.py", line 356, in fetch
TypeError: 'float' object is not subscriptable
```