### PR TITLE
Added support for RGB Matrix FeatherWing

### DIFF
--- a/adafruit_matrixportal/matrix.py
+++ b/adafruit_matrixportal/matrix.py
@@ -26,6 +26,7 @@ Implementation Notes
 
 """
 
+import os
 import board
 import displayio
 import rgbmatrix
@@ -50,9 +51,8 @@ class Matrix:
     # pylint: disable=too-few-public-methods,too-many-branches
     def __init__(self, *, width=64, height=32, bit_depth=2, alt_addr_pins=None):
 
-        # Detect the board type based on available pins
-        if hasattr(board, "MTX_ADDRA"):
-            # MatrixPortal M4
+        if "Matrix Portal M4" in os.uname().machine:
+            # MatrixPortal M4 Board
             addr_pins = [board.MTX_ADDRA, board.MTX_ADDRB, board.MTX_ADDRC]
             if height > 16:
                 addr_pins.append(board.MTX_ADDRD)
@@ -69,9 +69,18 @@ class Matrix:
             clock_pin = board.MTX_CLK
             latch_pin = board.MTX_LAT
             oe_pin = board.MTX_OE
-        elif hasattr(board, "D7"):
+        elif "Feather" in os.uname().machine:
+            print("Feather Detected")
+            # Feather Style Board
+            if height > 16:
+                addr_pins.append(board.A2)
+            rgb_pins = [board.D6, board.D5, board.D9, board.D11, board.D10, board.D12]
+            clock_pin = board.D13
+            latch_pin = board.D0
+            oe_pin = board.D1
+        else:
             # Metro/Grand Central Style Board
-            if height <= 16:
+            if alt_addr_pins is None and height <= 16:
                 raise RuntimeError(
                     "Pin A2 unavailable in this mode. Please specify alt_addr_pins."
                 )
@@ -80,15 +89,6 @@ class Matrix:
             clock_pin = board.A4
             latch_pin = board.D10
             oe_pin = board.D9
-        else:
-            # Feather Style Board
-            addr_pins = [board.A5, board.A4, board.A3]
-            if height > 16:
-                addr_pins.append(board.A2)
-            rgb_pins = [board.D6, board.D5, board.D9, board.D11, board.D10, board.D12]
-            clock_pin = board.D13
-            latch_pin = board.D0
-            oe_pin = board.D1
 
         # Alternate Address Pins
         if alt_addr_pins is not None:


### PR DESCRIPTION
Fixes #22. This also reduces the number of decision branches and informs Metro Users they need to pass in alt_addr_pins if using a 16x32 matrix.

Tested with:
 * MatrixPortal M4
 * Metro M4 Airlift Lite with RGB Matrix Shield
 * Feather M4 with RGB Matrix FeatherWing