### PR TITLE
Accept width & height to pass through to the Graphics constructor.

### DIFF
--- a/adafruit_matrixportal/matrixportal.py
+++ b/adafruit_matrixportal/matrixportal.py
@@ -80,7 +80,7 @@ class MatrixPortal:
         bit_depth=2,
         alt_addr_pins=None,
         color_order="RGB",
-        debug=False
+        debug=False,
         width=64,
         height=32,
     ):

--- a/adafruit_matrixportal/matrixportal.py
+++ b/adafruit_matrixportal/matrixportal.py
@@ -81,14 +81,16 @@ class MatrixPortal:
         alt_addr_pins=None,
         color_order="RGB",
         debug=False
+        width=64,
+        height=32,
     ):
 
         self._debug = debug
         self.graphics = Graphics(
             default_bg=default_bg,
             bit_depth=bit_depth,
-            width=64,
-            height=32,
+            width=width,
+            height=height,
             alt_addr_pins=alt_addr_pins,
             color_order=color_order,
             debug=debug,


### PR DESCRIPTION
Two new keyword arguments for MatrixPortal.__init__ that get passed to the Graphics constructor call.