### PR TITLE
Handle scrolling labels better if position not specified

### DIFF
--- a/adafruit_matrixportal/matrixportal.py
+++ b/adafruit_matrixportal/matrixportal.py
@@ -179,7 +179,11 @@ class MatrixPortal:
             text_scale = 1
         text_scale = round(text_scale)
         if scrolling:
-            text_position = (self.display.width, text_position[1])
+            if text_position is None:
+                # Center text if position not specified
+                text_position = (self.display.width, self.display.height // 2 - 1)
+            else:
+                text_position = (self.display.width, text_position[1])
 
         gc.collect()
 


### PR DESCRIPTION
Fixes #35. If Text position isn't specified, it is centered vertically.