### PR TITLE
Fixing the module import in readme example code

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Usage Example
     import time
     import board
     import terminalio
-    from adafruit_matrixportal import MatrixPortal
+    from adafruit_matrixportal.matrixportal import MatrixPortal
 
     # You can display in 'GBP', 'EUR' or 'USD'
     CURRENCY = "USD"


### PR DESCRIPTION
This fixes the import in the readme to resolve #39 