### PR TITLE
save color even if text doesn't exist yet for index

### DIFF
--- a/adafruit_matrixportal/matrixportal.py
+++ b/adafruit_matrixportal/matrixportal.py
@@ -260,7 +260,9 @@ class MatrixPortal:
             self._text[index].color = color
         else:
             raise IndexError(
-                f"index {index} is out of bounds. Please call add_text() and set_text() first."
+                "index {} is out of bounds. Please call add_text() and set_text() first.".format(
+                    index
+                )
             )
 
     def set_text(self, val, index=0):

--- a/adafruit_matrixportal/matrixportal.py
+++ b/adafruit_matrixportal/matrixportal.py
@@ -254,10 +254,10 @@ class MatrixPortal:
         :param index: Defaults to 0.
 
         """
-        if self._text[index]:
-            color = self.html_color_convert(color)
-            self._text_color[index] = color
-            self._text[index].color = color
+        if 0 <= index < len(self._text_color):
+            self._text_color[index] = self.html_color_convert(color)
+            if self._text[index] is not None:
+                self._text[index].color = self._text_color[index]
         else:
             raise IndexError(
                 "index {} is out of bounds. Please call add_text() and set_text() first.".format(

--- a/adafruit_matrixportal/matrixportal.py
+++ b/adafruit_matrixportal/matrixportal.py
@@ -259,7 +259,9 @@ class MatrixPortal:
             self._text_color[index] = color
             self._text[index].color = color
         else:
-            raise IndexError(f"index {index} is out of bounds. Please call add_text() and set_text() first.")
+            raise IndexError(
+                f"index {index} is out of bounds. Please call add_text() and set_text() first."
+            )
 
     def set_text(self, val, index=0):
         """Display text, with indexing into our list of text boxes.

--- a/adafruit_matrixportal/matrixportal.py
+++ b/adafruit_matrixportal/matrixportal.py
@@ -254,10 +254,12 @@ class MatrixPortal:
         :param index: Defaults to 0.
 
         """
-        self._text_color[index] = color
         if self._text[index]:
             color = self.html_color_convert(color)
+            self._text_color[index] = color
             self._text[index].color = color
+        else:
+            raise IndexError(f"index {index} is out of bounds. Please call add_text() and set_text() first.")
 
     def set_text(self, val, index=0):
         """Display text, with indexing into our list of text boxes.

--- a/adafruit_matrixportal/matrixportal.py
+++ b/adafruit_matrixportal/matrixportal.py
@@ -254,9 +254,9 @@ class MatrixPortal:
         :param index: Defaults to 0.
 
         """
+        self._text_color[index] = color
         if self._text[index]:
             color = self.html_color_convert(color)
-            self._text_color[index] = color
             self._text[index].color = color
 
     def set_text(self, val, index=0):


### PR DESCRIPTION
This code from the linked forum post makes red text using this version of the library: 
```python
import board
import terminalio
from adafruit_matrixportal.matrixportal import MatrixPortal
matrixportal = MatrixPortal()
matrixportal.add_text(
    text_font=terminalio.FONT,
    text_position=(0, (matrixportal.graphics.display.height // 2) - 1),
    #text_color=0x3d1f5c,
    text_transform=None,
)
matrixportal.set_text_color(0xFF0000,0)
matrixportal.set_text(" AWAY",0)
while True:
    pass

```
It can still raise an exception if you try to use 1 or any larger index that doesn't exist yet. But it does seem to work correctly for this most basic use case. 

Maybe it should check the length of `self._text_color` against the requested index and ignore values that are too large?