### PR TITLE
Add rotation parameter to Matrix

### DIFF
--- a/adafruit_matrixportal/matrix.py
+++ b/adafruit_matrixportal/matrix.py
@@ -47,12 +47,21 @@ class Matrix:
     :param list alt_addr_pins: An alternate set of address pins to use. Defaults to None
     :param string color_order: A string containing the letter "R", "G", and "B" in the
                                order you want. Defaults to "RGB"
+    :param int rotation: The rotation of the display in degrees clockwise. Must be in
+                               90 degree increments (0, 90, 180, 270)
 
     """
 
     # pylint: disable=too-few-public-methods,too-many-branches
     def __init__(
-        self, *, width=64, height=32, bit_depth=2, alt_addr_pins=None, color_order="RGB"
+        self,
+        *,
+        width=64,
+        height=32,
+        bit_depth=2,
+        alt_addr_pins=None,
+        color_order="RGB",
+        rotation=0
     ):
 
         if not isinstance(color_order, str):
@@ -141,6 +150,6 @@ class Matrix:
                 latch_pin=latch_pin,
                 output_enable_pin=oe_pin,
             )
-            self.display = framebufferio.FramebufferDisplay(matrix)
+            self.display = framebufferio.FramebufferDisplay(matrix, rotation)
         except ValueError:
             raise RuntimeError("Failed to initialize RGB Matrix") from ValueError


### PR DESCRIPTION
This is a WIP, but immediately upon getting started with my Matrix Portal, I found that I needed to hang the display upside down, and could not find a way to get to the underlying FrameBufferDisplay's rotation without modifying the Matrix definition.

If this is not needed because there's another way to set rotation, I'm all ears. If there are tests to update, I'm also game to do that, but I'm opening this draft PR as a way of starting a conversation around the code I think I need.

The rotation parameter I'm wanting to supply comes from this documentation: https://circuitpython.readthedocs.io/en/latest/shared-bindings/framebufferio/index.html#framebufferio.FramebufferDisplay