### PR TITLE
Fix graphics and network when inited directly with no params

### DIFF
--- a/adafruit_matrixportal/graphics.py
+++ b/adafruit_matrixportal/graphics.py
@@ -57,8 +57,12 @@ class Graphics(GraphicsBase):
         self,
         **kwargs,
     ):
-        default_bg = kwargs.pop("default_bg")
-        debug = kwargs.pop("debug")
+        default_bg = 0x000000
+        debug = False
+        if "default_bg" in kwargs:
+            default_bg = kwargs.pop("default_bg")
+        if "debug" in kwargs:
+            debug = kwargs.pop("debug")
 
         matrix = Matrix(**kwargs)
 

--- a/adafruit_matrixportal/network.py
+++ b/adafruit_matrixportal/network.py
@@ -50,9 +50,11 @@ class Network(NetworkBase):
 
     def __init__(self, **kwargs):
         extract_values = True
+        debug = False
         if "extract_values" in kwargs:
             extract_values = kwargs.pop("extract_values")
-        debug = kwargs.pop("debug")
+        if "debug" in kwargs:
+            debug = kwargs.pop("debug")
         wifi = WiFi(**kwargs)
 
         super().__init__(


### PR DESCRIPTION
Basically the same thing as the last fix, but for the rest of the parameters.