### PR TITLE
Wifi: handle cases when esp param is not provided

### DIFF
--- a/adafruit_matrixportal/wifi.py
+++ b/adafruit_matrixportal/wifi.py
@@ -77,7 +77,7 @@ class WiFi:
             )
 
         requests.set_socket(socket, self.esp)
-        if esp.is_connected:
+        if self.esp.is_connected:
             self.requests = requests
         self._manager = None
 


### PR DESCRIPTION
Use self.esp instead of param esp to account for cases when
caller for init did not pass ESP Object.

Fixes: https://github.com/adafruit/Adafruit_CircuitPython_MatrixPortal/issues/72