### PR TITLE
Updated for MatrixPortal S3

### DIFF
--- a/adafruit_matrixportal/matrix.py
+++ b/adafruit_matrixportal/matrix.py
@@ -79,8 +79,11 @@ class Matrix:
         if -1 in (red_index, green_index, blue_index):
             raise ValueError("color_order should contain R, G, and B")
 
-        if "Matrix Portal M4" in os.uname().machine:
-            # MatrixPortal M4 Board
+        if (
+            "Adafruit Matrix Portal" in os.uname().machine
+            or "Adafruit MatrixPortal" in os.uname().machine
+        ):
+            # MatrixPortal Board
             addr_pins = [board.MTX_ADDRA, board.MTX_ADDRB, board.MTX_ADDRC]
             if panel_height > 16:
                 addr_pins.append(board.MTX_ADDRD)

--- a/adafruit_matrixportal/network.py
+++ b/adafruit_matrixportal/network.py
@@ -26,10 +26,15 @@ Implementation Notes
 
 """
 
+import os
 import gc
 import neopixel
 from adafruit_portalbase.network import NetworkBase
-from adafruit_portalbase.wifi_coprocessor import WiFi
+
+if os.uname().sysname == "samd51":
+    from adafruit_portalbase.wifi_coprocessor import WiFi
+else:
+    from adafruit_portalbase.wifi_esp32s2 import WiFi
 
 __version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_MatrixPortal.git"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,16 @@ extensions = [
 # Uncomment the below if you use native CircuitPython modules such as
 # digitalio, micropython and busio. List the modules you use. Without it, the
 # autodoc module docs will fail to generate with a warning.
-autodoc_mock_imports = ["supervisor", "rtc", "rgbmatrix", "framebufferio", "secrets"]
+autodoc_mock_imports = [
+    "supervisor",
+    "rtc",
+    "rgbmatrix",
+    "framebufferio",
+    "secrets",
+    "wifi",
+    "ssl",
+    "socketpool",
+]
 
 
 intersphinx_mapping = {


### PR DESCRIPTION
Initial changes currently untested on MatrixPortal S3, but tested that it still works on the MatrixPortal M4.