### PR TITLE
add bitmaptools to mock modules

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,6 +36,7 @@ autodoc_mock_imports = [
     "wifi",
     "ssl",
     "socketpool",
+    "bitmaptools",
 ]
 
 


### PR DESCRIPTION
There was a change between when a recent PR was made and when it was merged in the Display Text library that resulted in the docs build here failing when that PR was merged. 

This is the fix that allows the docs to build successfully and get this repo back to passing.