### PR TITLE
Allow matrices to be initialized at arbitrary heights

### DIFF
--- a/adafruit_matrixportal/matrix.py
+++ b/adafruit_matrixportal/matrix.py
@@ -69,6 +69,8 @@ class Matrix:
         rotation=0,
     ):
         panel_height = height // tile_rows
+        self._width = width
+        self._height = height
 
         if not isinstance(color_order, str):
             raise ValueError("color_index should be a string")
@@ -158,6 +160,9 @@ class Matrix:
         if alt_addr_pins is not None:
             addr_pins = alt_addr_pins
 
+        if height < (2 << len(addr_pins)):
+            height = 2 << len(addr_pins)
+
         try:
             displayio.release_displays()
             if tile_rows > 1:
@@ -207,3 +212,13 @@ class Matrix:
             raise
         except ValueError:
             raise RuntimeError("Failed to initialize RGB Matrix") from ValueError
+
+    @property
+    def width(self):
+        """The initialized width of the display in pixels"""
+        return self._width
+
+    @property
+    def height(self):
+        """The intialized height of the display in pixels"""
+        return self._height


### PR DESCRIPTION
I came across an unusual situation where this is being used for a 24 pixel high display. I believe it's actually a 32-bit high display with only the top 24 pixels used. This change initializes it as a 32 pixel display and sets the width and height properties to the requested width and height.