### PR TITLE
Change pin names for generic feather case using RX and TX

### DIFF
--- a/adafruit_matrixportal/matrix.py
+++ b/adafruit_matrixportal/matrix.py
@@ -140,8 +140,8 @@ class Matrix:
                     board.D12,
                 ]
                 clock_pin = board.D13
-                latch_pin = board.D0
-                oe_pin = board.D1
+                latch_pin = board.RX
+                oe_pin = board.TX
         else:
             # Metro/Grand Central Style Board
             if alt_addr_pins is None and height <= 16:


### PR DESCRIPTION
Change pin names for generic feather case using RX and TX instead of D0 and D1 names.
This should make it work with any feather (for those pins).
Tested on the Adafruit ESP32S2 Feather.

Example:
```py
from adafruit_matrixportal.matrix import Matrix
matrix = Matrix()
```

Would cause:
```
Traceback (most recent call last):
  File "code.py", line 2, in <module>
  File "adafruit_matrixportal/matrix.py", line 144, in __init__
AttributeError: 'module' object has no attribute 'D1'
```