### PR TITLE
fix samd51 check for 10.x

### DIFF
--- a/adafruit_matrixportal/network.py
+++ b/adafruit_matrixportal/network.py
@@ -32,7 +32,7 @@ import os
 import neopixel
 from adafruit_portalbase.network import NetworkBase
 
-if os.uname().sysname == "samd51":
+if "samd51" in os.uname().sysname:
     from adafruit_portalbase.wifi_coprocessor import WiFi
 else:
     from adafruit_portalbase.wifi_esp32s2 import WiFi
@@ -63,7 +63,7 @@ class Network(NetworkBase):
         if "debug" in kwargs:
             debug = kwargs.pop("debug")
 
-        if os.uname().sysname != "samd51":
+        if "samd51" not in os.uname().sysname:
             if "external_spi" in kwargs:
                 kwargs.pop("external_spi")
             if "esp" in kwargs:


### PR DESCRIPTION
Resolves: #103 

The only 2 other instances of `os.uname().sysname` that I could find in the bundle were also in this library inside of `matrix.py` and they already use `in` logic with strings that I verified still works properly under 10.x. https://github.com/adafruit/Adafruit_CircuitPython_MatrixPortal/blob/main/adafruit_matrixportal/matrix.py#L105

This issue was originally noticed here: https://github.com/adafruit/Adafruit_CircuitPython_PortalBase/pull/115

And I tested these changes successfully with the reproducer from that thread.